### PR TITLE
Added CLI variable aux_throttle_channel = 0 (none) | 1-4 (aux1 - aux4)

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -203,7 +203,8 @@ static void updateArmingStatus(void)
         /* CHECK: Throttle */
         if (!armingConfig()->fixed_wing_auto_arm) {
             // Don't want this check if fixed_wing_auto_arm is in use - machine arms on throttle > LOW
-            if (calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC) != THROTTLE_LOW) {
+//            if (calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC) != THROTTLE_LOW && calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC) != COLLECTIVE_MID) {
+            if (calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC) == THROTTLE_HIGH) {
                 ENABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
             } else {
                 DISABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
@@ -540,7 +541,7 @@ void processRx(timeUs_t currentTimeUs)
     if (ARMING_FLAG(ARMED) && feature(FEATURE_MOTOR_STOP) && !STATE(FIXED_WING_LEGACY)) {
         static bool armedBeeperOn = false;
 
-        if (throttleStatus == THROTTLE_LOW) {
+        if (throttleStatus == THROTTLE_LOW || throttleStatus == COLLECTIVE_MID) { //sibi
             beeper(BEEPER_ARMED);
             armedBeeperOn = true;
         } else if (armedBeeperOn) {
@@ -655,7 +656,8 @@ void processRx(timeUs_t currentTimeUs)
         pidResetErrorAccumulators();
     }
     else if (STATE(FIXED_WING_LEGACY) || rcControlsConfig()->airmodeHandlingType == STICK_CENTER) {
-        if (throttleStatus == THROTTLE_LOW) {
+        if ((throttleStatus == THROTTLE_LOW) || (throttleStatus == COLLECTIVE_MID)) {    //sibi
+//      if (throttleStatus == THROTTLE_LOW) {    
             if (STATE(AIRMODE_ACTIVE) && !failsafeIsActive() && ARMING_FLAG(ARMED)) {
                 rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
 
@@ -678,7 +680,8 @@ void processRx(timeUs_t currentTimeUs)
     } else if (rcControlsConfig()->airmodeHandlingType == THROTTLE_THRESHOLD) {
         DISABLE_STATE(ANTI_WINDUP);
         //This case applies only to MR when Airmode management is throttle threshold activated
-        if (throttleStatus == THROTTLE_LOW && !STATE(AIRMODE_ACTIVE)) {
+//      if (throttleStatus == THROTTLE_LOW && !STATE(AIRMODE_ACTIVE)) {
+        if (throttleStatus != THROTTLE_HIGH && !STATE(AIRMODE_ACTIVE)) { //sibi
             pidResetErrorAccumulators();
         }
     }

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -47,6 +47,7 @@
 
 #include "flight/pid.h"
 #include "flight/failsafe.h"
+#include "flight/mixer.h"
 
 #include "io/gps.h"
 #include "io/beeper.h"
@@ -102,17 +103,27 @@ bool areSticksDeflectedMoreThanPosHoldDeadband(void)
 throttleStatus_e FAST_CODE NOINLINE calculateThrottleStatus(throttleStatusType_e type)
 {
     int value;
+    int auxValue; //sibi
+    const uint16_t collectiveThrottleChannel = mixerConfig()->auxThrottleChannel + NON_AUX_CHANNEL_COUNT -1; //sibi
     if (type == THROTTLE_STATUS_TYPE_RC) {
         value = rxGetChannelValue(THROTTLE);
+        auxValue = rxGetChannelValue(collectiveThrottleChannel); //sibi
     } else {
         value = rcCommand[THROTTLE];
+        auxValue = rcCommand[collectiveThrottleChannel]; //sibi
     }
 
     const uint16_t mid_throttle_deadband = rcControlsConfig()->mid_throttle_deadband;
-    if (feature(FEATURE_REVERSIBLE_MOTORS) && (value > (PWM_RANGE_MIDDLE - mid_throttle_deadband) && value < (PWM_RANGE_MIDDLE + mid_throttle_deadband)))
+    if (feature(FEATURE_REVERSIBLE_MOTORS) && (value > (PWM_RANGE_MIDDLE - mid_throttle_deadband) && value < (PWM_RANGE_MIDDLE + mid_throttle_deadband))) { //sibi
         return THROTTLE_LOW;
-    else if (!feature(FEATURE_REVERSIBLE_MOTORS) && (value < rxConfig()->mincheck))
+    }
+    if (!feature(FEATURE_REVERSIBLE_MOTORS) && (value < rxConfig()->mincheck) && !mixerConfig()->auxThrottleChannel) { //sibi
         return THROTTLE_LOW;
+    }
+    if (!feature(FEATURE_REVERSIBLE_MOTORS) && mixerConfig()->auxThrottleChannel && (auxValue < PWM_RANGE_MIN + 1)) { //sibi
+        return COLLECTIVE_MID;
+//        return THROTTLE_LOW;
+    }
 
     return THROTTLE_HIGH;
 }
@@ -193,6 +204,7 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
     if (STATE(AIRPLANE) && feature(FEATURE_MOTOR_STOP) && armingConfig()->fixed_wing_auto_arm) {
         // Auto arm on throttle when using fixedwing and motorstop
         if (throttleStatus != THROTTLE_LOW) {
+//      if (throttleStatus == THROTTLE_HIGH) { //sibi
             tryArm();
             return;
         }
@@ -208,7 +220,8 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
             if (ARMING_FLAG(ARMED) && !IS_RC_MODE_ACTIVE(BOXFAILSAFE) && rxIsReceivingSignal() && !failsafeIsActive()) {
                 const timeMs_t disarmDelay = currentTimeMs - rcDisarmTimeMs;
                 if (disarmDelay > armingConfig()->switchDisarmDelayMs) {
-                    if (armingConfig()->disarm_kill_switch || (throttleStatus == THROTTLE_LOW)) {
+//                  if (armingConfig()->disarm_kill_switch || (throttleStatus == THROTTLE_LOW)) {
+                    if (armingConfig()->disarm_kill_switch || (throttleStatus != THROTTLE_HIGH)) { //sibi
                         disarm(DISARM_SWITCH);
                     }
                 }

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -42,7 +42,8 @@ typedef enum rc_alias {
 
 typedef enum {
     THROTTLE_LOW = 0,
-    THROTTLE_HIGH
+    THROTTLE_HIGH,
+    COLLECTIVE_MID      //sibi
 } throttleStatus_e;
 
 typedef enum {

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -715,7 +715,7 @@ groups:
       - name: aux_throttle_channel
         field: auxThrottleChannel
         min: 0
-        max: MAX_AUX_CHANNEL_COUNT
+        max: 4
 
   - name: PG_REVERSIBLE_MOTORS_CONFIG
     type: reversibleMotorsConfig_t

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -257,10 +257,6 @@ void failsafeUpdateRcCommandValues(void)
 void failsafeApplyControlInput(void)
 {
     // Prepare FAILSAFE_CHANNEL_AUTO values for rcCommand
-    int8_t collectiveThrottleChannel = (mixerConfig()->auxThrottleChannel < 4) ? mixerConfig()->auxThrottleChannel : 0;  // sibi
-    if (collectiveThrottleChannel) {
-        collectiveThrottleChannel += NON_AUX_CHANNEL_COUNT - 1;
-    }
     int16_t autoRcCommand[4];
     if (STATE(FIXED_WING_LEGACY)) {
         autoRcCommand[ROLL] = pidAngleToRcCommand(failsafeConfig()->failsafe_fw_roll_angle, pidProfile()->max_angle_inclination[FD_ROLL]);
@@ -291,7 +287,8 @@ void failsafeApplyControlInput(void)
                         break;
 
                     case THROTTLE:
-                        rcCommand[idx] = feature(FEATURE_REVERSIBLE_MOTORS) ? PWM_RANGE_MIDDLE : getThrottleIdleValue();
+                        rcCommand[idx] = (feature(FEATURE_REVERSIBLE_MOTORS) || mixerConfig()->auxThrottleChannel) ? PWM_RANGE_MIDDLE : getThrottleIdleValue(); //sibi
+//                        rcCommand[idx] = feature(FEATURE_REVERSIBLE_MOTORS) ? PWM_RANGE_MIDDLE : getThrottleIdleValue();
                         break;
                 }
                 break;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -279,14 +279,18 @@ void mixerResetDisarmedMotors(void)
         throttleRangeMin = throttleDeadbandHigh;
         throttleRangeMax = motorConfig()->maxthrottle;
     } else {
-        motorZeroCommand = motorConfig()->mincommand;
+        if (mixerConfig()->auxThrottleChannel) {       //sibi
+            motorZeroCommand = reversibleMotorsConfig()->neutral;
+        } else {
+            motorZeroCommand = motorConfig()->mincommand;
+        }
         throttleRangeMin = getThrottleIdleValue();
         throttleRangeMax = motorConfig()->maxthrottle;
     }
 
     reversibleMotorsThrottleState = MOTOR_DIRECTION_FORWARD;
 
-    if (feature(FEATURE_MOTOR_STOP)) {
+    if (feature(FEATURE_MOTOR_STOP) || mixerConfig()->auxThrottleChannel) { //sibi
         motorValueWhenStopped = motorZeroCommand;
     } else {
         motorValueWhenStopped = getThrottleIdleValue();
@@ -442,8 +446,11 @@ void writeAllMotors(int16_t mc)
 
 void stopMotors(void)
 {
-    writeAllMotors(feature(FEATURE_REVERSIBLE_MOTORS) ? reversibleMotorsConfig()->neutral : motorConfig()->mincommand);
-
+    if (mixerConfig()->auxThrottleChannel) {    //sibi
+        writeAllMotors(reversibleMotorsConfig()->neutral);
+    } else {
+        writeAllMotors(feature(FEATURE_REVERSIBLE_MOTORS) ? reversibleMotorsConfig()->neutral : motorConfig()->mincommand);
+    }
     delay(50); // give the timers and ESCs a chance to react.
 }
 
@@ -546,6 +553,9 @@ void FAST_CODE mixTable(const float dT)
         if (feature(FEATURE_THR_VBAT_COMP) && isAmperageConfigured() && feature(FEATURE_VBAT)) {                
             mixerThrottleCommand = MIN(throttleRangeMin + (mixerThrottleCommand - throttleRangeMin) * calculateThrottleCompensationFactor(), throttleRangeMax);
         }
+        if (mixerConfig()->auxThrottleChannel) { //sibi
+            motorValueWhenStopped = getReversibleMotorsThrottleDeadband();
+        }
     }
 
     throttleMin = throttleRangeMin;
@@ -603,6 +613,7 @@ motorStatus_e getMotorStatus(void)
     }
 
     if (calculateThrottleStatus(feature(FEATURE_REVERSIBLE_MOTORS) ? THROTTLE_STATUS_TYPE_COMMAND : THROTTLE_STATUS_TYPE_RC) == THROTTLE_LOW) {
+//  if (calculateThrottleStatus(feature(FEATURE_REVERSIBLE_MOTORS) ? THROTTLE_STATUS_TYPE_COMMAND : THROTTLE_STATUS_TYPE_RC) != THROTTLE_HIGH) { //sibi
         if ((STATE(FIXED_WING_LEGACY) || !STATE(AIRMODE_ACTIVE)) && (!(navigationIsFlyingAutonomousMode() && navConfig()->general.flags.auto_overrides_motor_stop)) && (!failsafeIsActive())) {
             return MOTOR_STOPPED_USER;
         }

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -308,6 +308,12 @@ void servoMixer(float dT)
     input[INPUT_RC_CH16]     = GET_RX_CHANNEL_INPUT(AUX12);
 #undef GET_RX_CHANNEL_INPUT
 
+    int8_t collectiveThrottleChannel = mixerConfig()->auxThrottleChannel;  // sibi
+    if (collectiveThrottleChannel && !ARMING_FLAG(ARMED)) {
+        collectiveThrottleChannel += 7;
+        input[collectiveThrottleChannel] = -500;
+    }
+    
     for (int i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
         servo[i] = 0;
     }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1670,7 +1670,8 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_LAUNCH_WAIT(navigationF
     //allow to leave NAV_LAUNCH_MODE if it has being enabled as feature by moving sticks with low throttle.
     if (feature(FEATURE_FW_LAUNCH)) {
         throttleStatus_e throttleStatus = calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC);
-        if ((throttleStatus == THROTTLE_LOW) && (areSticksDeflectedMoreThanPosHoldDeadband())) {
+//      if ((throttleStatus == THROTTLE_LOW) && (areSticksDeflectedMoreThanPosHoldDeadband())) {
+        if ((throttleStatus != THROTTLE_HIGH) && (areSticksDeflectedMoreThanPosHoldDeadband())) { //sibi
             abortFixedWingLaunch();
             return NAV_FSM_EVENT_SWITCH_TO_IDLE;
         }
@@ -3076,7 +3077,8 @@ static navigationFSMEvent_t selectNavEventFromBoxModeInput(void)
                 // If we were in LAUNCH mode - force switch to IDLE only if the throttle is low
                 if (FLIGHT_MODE(NAV_LAUNCH_MODE)) {
                     throttleStatus_e throttleStatus = calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC);
-                    if (throttleStatus != THROTTLE_LOW)
+//                  if (throttleStatus != THROTTLE_LOW)
+                    if (throttleStatus == THROTTLE_HIGH) //sibi
                         return NAV_FSM_EVENT_NONE;
                     else
                         return NAV_FSM_EVENT_SWITCH_TO_IDLE;

--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -146,7 +146,8 @@ static void applyFixedWingLaunchIdleLogic(void)
     else
     {
         static float timeThrottleRaisedMs;
-        if (calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC) == THROTTLE_LOW)
+//      if (calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC) == THROTTLE_LOW)
+        if (calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC) != THROTTLE_HIGH) //sibi
         {
             timeThrottleRaisedMs = millis();
         }

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -172,7 +172,8 @@ void setupMulticopterAltitudeController(void)
     }
     else {
         // If throttle status is THROTTLE_LOW - use Thr Mid anyway
-        if (throttleStatus == THROTTLE_LOW) {
+//      if (throttleStatus == THROTTLE_LOW || throttleStatus == COLLECTIVE_MID) { //sibi
+        if (throttleStatus != THROTTLE_HIGH) { //sibi
             altHoldThrottleRCZero = rcLookupThrottleMid();
         }
         else {
@@ -187,7 +188,8 @@ void setupMulticopterAltitudeController(void)
 
     // Force AH controller to initialize althold integral for pending takeoff on reset
     // Signal for that is low throttle _and_ low actual altitude
-    if (throttleStatus == THROTTLE_LOW && fabsf(navGetCurrentActualPositionAndVelocity()->pos.z) <= 50.0f) {
+//  if (throttleStatus == THROTTLE_LOW && fabsf(navGetCurrentActualPositionAndVelocity()->pos.z) <= 50.0f) {
+    if (throttleStatus != THROTTLE_HIGH && fabsf(navGetCurrentActualPositionAndVelocity()->pos.z) <= 50.0f) { //sibi
         prepareForTakeoffOnReset = true;
     }
 }

--- a/src/main/telemetry/frsky_d.c
+++ b/src/main/telemetry/frsky_d.c
@@ -197,7 +197,7 @@ static void sendThrottleOrBatterySizeAsRpm(void)
     sendDataHead(ID_RPM);
     if (ARMING_FLAG(ARMED)) {
         const throttleStatus_e throttleStatus = calculateThrottleStatus(THROTTLE_STATUS_TYPE_RC);
-        if (throttleStatus == THROTTLE_LOW && feature(FEATURE_MOTOR_STOP))
+        if (throttleStatus != THROTTLE_HIGH && feature(FEATURE_MOTOR_STOP)) //sibi
                     throttleForRPM = 0;
         serialize16(throttleForRPM);
     } else {


### PR DESCRIPTION
Modified failsafe procedures to match the needs of collective pitch vehicles:
- if aux_throttle_channel = 0 --> INAV failsafe as is in iNavFlight/inav
- if aux_throttle_channel > 0 --> apply throttle handling to the specified aux channel, set collective pitch according to the failsafe procedure (landing throttle --> collective pitch for landing, neutral on disarm when landed and procedure drop_it, etc)
- treat cp vehicles mostly as 3d multis but without reversing yaw control.